### PR TITLE
Enhance natural language search

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,6 +9,7 @@
 <h1>広報誌検索</h1>
 <input type="text" id="query" placeholder="検索ワードを入力" style="width:80%;">
 <button id="searchBtn">検索</button>
+<button id="downloadBtn" style="display:none">ダウンロード</button>
 <div id="results"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.2/papaparse.min.js"></script>
 <script src="search.js"></script>


### PR DESCRIPTION
## Summary
- expand search input page with a download button
- support simple natural language query parsing with synonyms
- concatenate matched articles into a single Markdown and allow downloading

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile scripts/update_index.py`


------
https://chatgpt.com/codex/tasks/task_e_684942a3efd083208f0d434e20765a3d