### PR TITLE
Add loading spinner during searches

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,7 @@
 <input type="text" id="query" placeholder="検索ワードを入力" style="width:80%;">
 <button id="searchBtn">検索</button>
 <button id="downloadBtn" style="display:none">ダウンロード</button>
+<div id="spinner" class="spinner" style="display:none"></div>
 <div id="results"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.2/papaparse.min.js"></script>
 <script src="search.js"></script>

--- a/docs/search.js
+++ b/docs/search.js
@@ -79,7 +79,9 @@ async function fetchCombinedMarkdown(results) {
 window.addEventListener('DOMContentLoaded', async () => {
   const entries = await loadIndex();
   const downloadBtn = document.getElementById('downloadBtn');
+  const spinner = document.getElementById('spinner');
   document.getElementById('searchBtn').addEventListener('click', async () => {
+    spinner.style.display = 'inline-block';
     const q = document.getElementById('query').value;
     const results = await search(entries, q);
     const container = document.getElementById('results');
@@ -87,6 +89,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     downloadBtn.style.display = 'none';
     if(!results.length) {
       container.textContent = '見つかりませんでした';
+      spinner.style.display = 'none';
       return;
     }
     const limited = results.slice(0, 20);
@@ -97,5 +100,6 @@ window.addEventListener('DOMContentLoaded', async () => {
     container.appendChild(pre);
     downloadBtn.style.display = 'inline';
     downloadBtn.onclick = () => download('results.md', md);
+    spinner.style.display = 'none';
   });
 });

--- a/docs/style.css
+++ b/docs/style.css
@@ -4,3 +4,20 @@ body { font-family: sans-serif; margin: 2em; }
 .result h3 { margin: 0; }
 .markdown { white-space: pre-wrap; background: #f9f9f9; padding: 1em; }
 #license { position: absolute; top: 1em; right: 1em; }
+
+/* Loading spinner */
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #555;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+  display: inline-block;
+  margin-left: 1em;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
- display a loading spinner during search and article fetches
- add CSS styles for animated spinner

## Testing
- `python -m py_compile scripts/update_index.py`

------
https://chatgpt.com/codex/tasks/task_e_684947b379348320aec9413c6ec1e12c