### PR TITLE
Fix row indexing for article retrieval

### DIFF
--- a/docs/search.js
+++ b/docs/search.js
@@ -27,7 +27,7 @@ async function fetchArticle(entry) {
     throw new Error('Failed to load CSV');
   }
   const parsed = Papa.parse(text, {header:true});
-  const row = parsed.data[entry.row-1];
+  const row = parsed.data[entry.row];
   return row && row['記事本文'] || '';
 }
 


### PR DESCRIPTION
## Summary
- correct off-by-one error when fetching article rows in `search.js`

## Testing
- `python -m py_compile scripts/update_index.py`


------
https://chatgpt.com/codex/tasks/task_e_68494cb4781883208ab71b9baa843021