### PR TITLE
Fix GitHub Actions push permissions

### DIFF
--- a/.github/workflows/ensure-utf8.yml
+++ b/.github/workflows/ensure-utf8.yml
@@ -1,4 +1,6 @@
 name: Ensure UTF-8 CSV
+permissions:
+  contents: write
 on:
   push:
     paths:

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -1,4 +1,6 @@
 name: Update index
+permissions:
+  contents: write
 on:
   push:
     paths:


### PR DESCRIPTION
## Summary
- allow `ensure-utf8.yml` workflow to push to the repo
- allow `update-index.yml` workflow to push to the repo

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684951c3795c832096af03e1933276c8