### PR TITLE
Add debug logs for search JavaScript

### DIFF
--- a/docs/search.js
+++ b/docs/search.js
@@ -1,9 +1,17 @@
+function debug() {
+  console.debug.apply(console, arguments);
+}
+
 async function loadIndex() {
+  debug('Loading index.json');
   const res = await fetch('index.json');
-  return await res.json();
+  const data = await res.json();
+  debug('Index loaded');
+  return data;
 }
 
 function createMarkdown(entry, article) {
+  debug('Creating markdown for', entry.id);
   return `# ${entry.article_title}\n\n- 自治体: ${entry.municipality}\n- 日付: ${entry.date}\n- 号: ${entry.issue_title}\n- カテゴリ: ${entry.category}\n\n${article}`;
 }
 
@@ -14,6 +22,7 @@ function githubApiUrl(path) {
 }
 
 async function fetchArticle(entry) {
+  debug('Fetching article from', entry.source, 'row', entry.row);
   const apiUrl = githubApiUrl(entry.source);
   const res = await fetch(apiUrl);
   const info = await res.json();
@@ -28,7 +37,9 @@ async function fetchArticle(entry) {
   }
   const parsed = Papa.parse(text, {header:true});
   const row = parsed.data[entry.row - 1];
-  return row && row['記事本文'] || '';
+  const body = row && row['記事本文'] || '';
+  debug('Fetched article length', body.length);
+  return body;
 }
 
 function download(name, content) {
@@ -47,12 +58,15 @@ const SYNONYMS = {
 };
 
 function parseQuery(q) {
+  debug('Parsing query', q);
   let order = null;
   if(q.includes('新しい順')) order = 'desc';
   if(q.includes('古い順')) order = 'asc';
   q = q.replace(/新しい順.*|古い順.*|の記事.*|を.*$/g, '');
   const words = q.split(/[\s,とや]+/).filter(Boolean);
-  return { keywords: words, order };
+  const result = { keywords: words, order };
+  debug('Parsed query', result);
+  return result;
 }
 
 function expandGroups(words) {
@@ -74,32 +88,46 @@ function toDate(str) {
 
 async function search(entries, q) {
   const {keywords, order} = parseQuery(q.trim());
-  if(!keywords.length) return [];
+  if(!keywords.length) {
+    debug('No keywords provided');
+    return [];
+  }
+  debug('Searching for', keywords, 'order:', order);
   const groups = expandGroups(keywords);
   let results = entries.filter(e => entryMatches(e, groups));
+  debug('Entries matched', results.length);
   if(order) {
+    debug('Sorting results');
     results.sort((a,b) => order === 'desc' ? toDate(b.date) - toDate(a.date) : toDate(a.date) - toDate(b.date));
   }
   return results;
 }
 
 async function fetchCombinedMarkdown(results) {
+  debug('Building combined markdown for', results.length, 'results');
   let out = '';
   for(const e of results) {
+    debug('Processing entry', e.id);
     const article = await fetchArticle(e);
     out += createMarkdown(e, article) + '\n\n';
   }
-  return out.trim();
+  const trimmed = out.trim();
+  debug('Combined markdown length', trimmed.length);
+  return trimmed;
 }
 
 window.addEventListener('DOMContentLoaded', async () => {
+  debug('DOM loaded');
   const entries = await loadIndex();
   const downloadBtn = document.getElementById('downloadBtn');
   const spinner = document.getElementById('spinner');
   document.getElementById('searchBtn').addEventListener('click', async () => {
+    debug('Search button clicked');
     if (spinner) spinner.style.display = 'inline-block';
     const q = document.getElementById('query').value;
+    debug('Query:', q);
     const results = await search(entries, q);
+    debug('Results count', results.length);
     const container = document.getElementById('results');
     container.innerHTML = '';
     if (downloadBtn) downloadBtn.style.display = 'none';
@@ -109,7 +137,9 @@ window.addEventListener('DOMContentLoaded', async () => {
       return;
     }
     const limited = results.slice(0, 20);
+    debug('Fetching markdown for', limited.length, 'entries');
     const md = await fetchCombinedMarkdown(limited);
+    debug('Markdown ready');
     const pre = document.createElement('pre');
     pre.className = 'markdown';
     pre.textContent = md;


### PR DESCRIPTION
## Summary
- output detailed status information to the browser console in `search.js`

## Testing
- `python -m py_compile scripts/ensure_utf8.py scripts/update_index.py`

------
https://chatgpt.com/codex/tasks/task_e_6849563640248320b8ff613370676c01