### PR TITLE
Fix encoding when loading CSVs

### DIFF
--- a/docs/search.js
+++ b/docs/search.js
@@ -27,11 +27,15 @@ async function fetchArticle(entry) {
   const res = await fetch(apiUrl);
   const info = await res.json();
   let text;
-  if (info.content) {
-    text = atob(info.content.replace(/\n/g, ''));
-  } else if (info.download_url) {
+  if (info.download_url) {
     const raw = await fetch(info.download_url);
-    text = await raw.text();
+    const buf = await raw.arrayBuffer();
+    text = new TextDecoder('utf-8').decode(buf);
+  } else if (info.content) {
+    const binary = atob(info.content.replace(/\n/g, ''));
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    text = new TextDecoder('utf-8').decode(bytes);
   } else {
     throw new Error('Failed to load CSV');
   }


### PR DESCRIPTION
## Summary
- fix how docs/search.js decodes CSV files so UTF-8 text is parsed correctly

## Testing
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68495ae0f4f08320aafd9d1f5233a75f