### PR TITLE
Switch to GitHub Models for index

### DIFF
--- a/.github/models/extract.prompt.yaml
+++ b/.github/models/extract.prompt.yaml
@@ -1,0 +1,18 @@
+name: Extract summary and keywords
+description: Summarize municipal bulletin articles and extract keywords
+model: phi4
+modelParameters:
+  temperature: 0.2
+  maxTokens: 256
+messages:
+  - role: system
+    content: |
+      あなたは地方自治体の広報誌記事から情報を抽出するアシスタントです。
+      与えられたテキストを読み、内容を一文で要約し、重要なキーワードを5個以内で抽出してください。
+      出力は次のJSON形式で返してください。
+      {
+        "summary": "要約",
+        "keywords": ["keyword1", "keyword2", "..."]
+      }
+  - role: user
+    content: "{{text}}"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## インデックスの更新
 
-CSV ファイルが追加・変更されると GitHub Actions (`.github/workflows/update-index.yml`) が実行され、`scripts/update_index.py` を用いてインデックスを再生成します。OpenAI API キー (`OPENAI_API_KEY`) が設定されている場合は LLM を利用して要約とタグ付けを行います。キーがない場合は簡易的な処理で代替します。
+CSV ファイルが追加・変更されると GitHub Actions (`.github/workflows/update-index.yml`) が実行され、`scripts/update_index.py` を用いてインデックスを再生成します。GitHub Models の SLM **Phi4** を利用して要約とキーワード抽出を行い、失敗した場合は簡易的な処理で代替します。
 
 ### 手動で実行する場合
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pandas
-openai
 chardet

--- a/scripts/update_index.py
+++ b/scripts/update_index.py
@@ -2,49 +2,22 @@ import os
 import json
 import glob
 import pandas as pd
-import openai
-from typing import List
+import subprocess
+import re
+from typing import List, Tuple
 
 # Directory containing CSV files
 CSV_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'csv')
 OUTPUT_JSON = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'docs', 'index.json')
 
-OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
-if OPENAI_API_KEY:
-    openai.api_key = OPENAI_API_KEY
+PROMPT_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.github', 'models', 'extract.prompt.yaml')
 
-def summarize(text: str) -> str:
+def fallback_summary(text: str) -> str:
     text = text.strip().replace('\n', ' ')
-    if not text:
-        return ""
-    if OPENAI_API_KEY:
-        try:
-            resp = openai.chat.completions.create(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "system", "content": "Summarize the following Japanese text in one sentence."},
-                         {"role": "user", "content": text[:4000]}],
-                max_tokens=60
-            )
-            return resp.choices[0].message.content.strip()
-        except Exception as e:
-            print("openai error", e)
-    # fallback simple summary
     return text[:120] + ("..." if len(text) > 120 else "")
 
-def extract_tags(text: str) -> List[str]:
-    if OPENAI_API_KEY:
-        try:
-            resp = openai.chat.completions.create(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "system", "content": "日本語テキストを読んで重要なキーワードを最大5個抽出してください。結果はカンマ区切りで返してください。"},
-                         {"role": "user", "content": text[:4000]}],
-                max_tokens=20
-            )
-            line = resp.choices[0].message.content.strip()
-            return [t.strip() for t in line.split(',') if t.strip()]
-        except Exception as e:
-            print("openai error", e)
-    # fallback: naive tag extraction using top words
+
+def fallback_tags(text: str) -> List[str]:
     words = [w for w in text.replace('\n', ' ').split(' ') if len(w) > 3]
     seen = []
     for w in words:
@@ -53,6 +26,36 @@ def extract_tags(text: str) -> List[str]:
         if len(seen) == 5:
             break
     return seen
+
+
+def run_phi4(text: str) -> Tuple[str, List[str]]:
+    text = text.strip().replace('\n', ' ')
+    if not text:
+        return "", []
+    try:
+        result = subprocess.run([
+            'gh', 'models', 'run', PROMPT_PATH,
+            '--var', f'text={text}'
+        ], check=True, capture_output=True, text=True)
+        out = result.stdout.strip()
+        match = re.search(r'\{.*\}', out, re.DOTALL)
+        if match:
+            data = json.loads(match.group(0))
+            summary = data.get('summary', '').strip()
+            tags = data.get('keywords') or data.get('tags') or []
+            if isinstance(tags, str):
+                tags = [t.strip() for t in re.split(r'[、,\s]+', tags) if t.strip()]
+            return summary, tags
+    except Exception as e:
+        print('gh models error', e)
+    return "", []
+
+
+def extract_summary_and_tags(text: str) -> Tuple[str, List[str]]:
+    summary, tags = run_phi4(text)
+    if summary or tags:
+        return summary, tags
+    return fallback_summary(text), fallback_tags(text)
 
 
 def detect_encoding(path: str) -> str:
@@ -77,6 +80,7 @@ def build_index() -> list:
         df = load_csv(file)
         for i, row in df.iterrows():
             article_text = str(row.get('記事本文', ''))
+            summary, tags = extract_summary_and_tags(article_text)
             entry = {
                 'id': f"{os.path.basename(file)}-{i}",
                 'municipality': str(row.get('自治体名', '')),
@@ -84,8 +88,8 @@ def build_index() -> list:
                 'issue_title': str(row.get('発行号タイトル', '')),
                 'article_title': str(row.get('記事タイトル', '')),
                 'category': str(row.get('カテゴリ', '')),
-                'summary': summarize(article_text),
-                'tags': extract_tags(article_text),
+                'summary': summary,
+                'tags': tags,
                 'source': os.path.relpath(file, os.path.dirname(OUTPUT_JSON)),
                 'row': i + 1
             }


### PR DESCRIPTION
## Summary
- use GitHub Models phi4 in the indexing script
- add prompt file under `.github/models`
- drop OpenAI dependency
- document use of phi4 in README

## Testing
- `python -m py_compile scripts/update_index.py`
- `python scripts/update_index.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684f96533e388320b513a27ca0d50395