### PR TITLE
Add link to advanced search and clarify index update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 
 [広報誌検索ページ](https://mitsuo-koikawa.github.io/Municipal-Bulletin)
 
+GitHub アカウントで認証して利用する [高度な検索ページ](https://mitsuo-koikawa.github.io/Municipal-Bulletin/advanced.html) も用意しました。こちらでは入力した文章を GitHub Models の **Phi4** で解析し、インデックスから関連する記事を検索します。検索時のアクセスログは GitHub 上のストレージに30日間保存されます。リポジトリ Collaborator のみ利用可能です。
+
 ## インデックスの更新
 
-CSV ファイルが追加・変更されると GitHub Actions (`.github/workflows/update-index.yml`) が実行され、`scripts/update_index.py` を用いてインデックスを再生成します。GitHub Models の SLM **Phi4** を利用して要約とキーワード抽出を行い、失敗した場合は簡易的な処理で代替します。
+CSV ファイルが追加・変更されても自動では更新されません。以前は `.github/workflows/update-index.yml` が自動実行されていましたが、GitHub Models の SLM **Phi4** を利用する際のトークン消費を抑えるため現在は手動実行としています。インデックスの生成には `scripts/update_index.py` を使用し、失敗した場合は簡易的な処理で代替します。
 
 ### 手動で実行する場合
 

--- a/docs/advanced.html
+++ b/docs/advanced.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>高度な検索</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>高度な検索</h1>
+<p>このページは本リポジトリの Collaborator のみ利用できます。</p>
+<div id="login">
+  <button id="loginBtn">GitHubでログイン</button>
+</div>
+<div id="searchSection" style="display:none">
+  <textarea id="query" placeholder="文章を入力" style="width:80%;height:4em;"></textarea>
+  <button id="searchBtn">検索</button>
+  <button id="downloadBtn" style="display:none">ダウンロード</button>
+  <div id="spinner" class="spinner" style="display:none"></div>
+  <div id="results"></div>
+</div>
+<script src="advanced.js"></script>
+</body>
+</html>

--- a/docs/advanced.js
+++ b/docs/advanced.js
@@ -1,0 +1,100 @@
+const CLIENT_ID = 'YOUR_CLIENT_ID'; // Replace with OAuth app client ID
+const REDIRECT_URI = location.origin + location.pathname;
+
+function login() {
+  const state = Math.random().toString(36).slice(2);
+  localStorage.setItem('oauth_state', state);
+  const url = `https://github.com/login/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&scope=read:user&state=${state}`;
+  location.href = url;
+}
+
+async function exchange(code, state) {
+  const saved = localStorage.getItem('oauth_state');
+  if(state !== saved) return;
+  const res = await fetch(`/api/exchange_token?code=${code}`, {method: 'POST'});
+  if(res.ok) {
+    const data = await res.json();
+    if(data.token) {
+      localStorage.setItem('gh_token', data.token);
+    }
+  }
+}
+
+function getToken() {
+  return localStorage.getItem('gh_token');
+}
+
+async function advancedSearch(q) {
+  const token = getToken();
+  if(!token) return null;
+  const res = await fetch('/api/advsearch?format=markdown', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + token
+    },
+    body: JSON.stringify({q})
+  });
+  if(res.ok) {
+    return await res.text();
+  }
+  return null;
+}
+
+async function checkAccess() {
+  const token = getToken();
+  if(!token) return false;
+  const res = await fetch('/api/advsearch?check=1', {
+    headers: { 'Authorization': 'Bearer ' + token }
+  });
+  return res.status === 204;
+}
+
+window.addEventListener('DOMContentLoaded', async () => {
+  const url = new URL(location.href);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  if(code) {
+    await exchange(code, state);
+    history.replaceState(null, '', location.pathname);
+  }
+  const token = getToken();
+  if(!token) {
+    document.getElementById('loginBtn').onclick = login;
+  } else {
+    if(!(await checkAccess())) {
+      document.getElementById('login').innerHTML = 'このページを利用する権限がありません';
+      return;
+    }
+    document.getElementById('login').style.display = 'none';
+    document.getElementById('searchSection').style.display = 'block';
+    document.getElementById('searchBtn').onclick = async () => {
+      const spinner = document.getElementById('spinner');
+      spinner.style.display = 'inline-block';
+      const q = document.getElementById('query').value;
+      const md = await advancedSearch(q);
+      spinner.style.display = 'none';
+      const container = document.getElementById('results');
+      container.innerHTML = '';
+      if(!md) {
+        container.textContent = '検索に失敗しました';
+        return;
+      }
+      const pre = document.createElement('pre');
+      pre.className = 'markdown';
+      pre.textContent = md;
+      container.appendChild(pre);
+      const dl = document.getElementById('downloadBtn');
+      dl.style.display = 'inline';
+      dl.onclick = () => {
+        const blob = new Blob([md], {type: 'text/markdown'});
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'results.md';
+        a.click();
+        URL.revokeObjectURL(url);
+      };
+    };
+  }
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,7 @@
     <img alt="CC BY 4.0" src="https://licensebuttons.net/l/by/4.0/88x31.png" style="border-width:0; vertical-align: middle;">
   </a>
 </div>
+<p><a href="advanced.html">高度な検索(要 GitHub 認証・Collaborator 限定)</a></p>
 <h1>広報誌検索</h1>
 <input type="text" id="query" placeholder="検索ワードを入力" style="width:80%;">
 <button id="searchBtn">検索</button>

--- a/mcp_server/Dockerfile
+++ b/mcp_server/Dockerfile
@@ -3,6 +3,16 @@ FROM mcr.microsoft.com/azure-functions/python:4-python3.10
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 
+# Install gh CLI and models extension
+RUN apt-get update && \
+    apt-get install -y git curl && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && apt-get install -y gh && \
+    gh extension install github/gh-models && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 COPY mcp_server/ /home/site/wwwroot/
 COPY csv /home/site/wwwroot/csv
 COPY docs/index.json /home/site/wwwroot/docs/index.json

--- a/mcp_server/advsearch/__init__.py
+++ b/mcp_server/advsearch/__init__.py
@@ -1,0 +1,148 @@
+import json
+import os
+import re
+import pandas as pd
+import subprocess
+import requests
+import datetime
+import azure.functions as func
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+INDEX_PATH = os.path.join(BASE_DIR, 'docs', 'index.json')
+CSV_DIR = os.path.join(BASE_DIR, 'csv')
+PROMPT_PATH = os.path.join(BASE_DIR, '.github', 'models', 'extract.prompt.yaml')
+REPO = os.getenv('REPO', 'Mitsuo-Koikawa/Municipal-Bulletin')
+
+with open(INDEX_PATH, 'r', encoding='utf-8') as f:
+    INDEX = json.load(f)
+
+SYNONYMS = {
+    '移住': ['移住', '住み替え', '移転'],
+    '空き家': ['空き家', '空家']
+}
+
+def github_user(token: str):
+    headers = {'Authorization': f'token {token}', 'Accept': 'application/vnd.github+json'}
+    r = requests.get('https://api.github.com/user', headers=headers)
+    if r.status_code == 200:
+        return r.json()
+    return None
+
+def run_phi4(text: str):
+    token = os.getenv('GH_MODELS_TOKEN')
+    if not token:
+        return []
+    env = os.environ.copy()
+    env['GH_TOKEN'] = token
+    try:
+        res = subprocess.run([
+            'gh', 'models', 'run', PROMPT_PATH,
+            '--var', f'text={text}'
+        ], check=True, capture_output=True, text=True, env=env)
+        out = res.stdout.strip()
+        m = re.search(r'\{.*\}', out, re.DOTALL)
+        if m:
+            data = json.loads(m.group(0))
+            tags = data.get('keywords') or data.get('tags') or []
+            if isinstance(tags, str):
+                tags = [t.strip() for t in re.split(r'[、,\s]+', tags) if t.strip()]
+            return tags
+    except Exception as e:
+        print('phi4 error', e)
+    return []
+
+def expand_groups(words):
+    return [SYNONYMS.get(w, [w]) for w in words]
+
+def includes_any(text: str, arr):
+    return any(a in text for a in arr)
+
+def entry_matches(entry, groups):
+    text = ' '.join([
+        entry.get('article_title', ''),
+        entry.get('summary', ''),
+        ' '.join(entry.get('tags', [])),
+        entry.get('category', '')
+    ])
+    return all(includes_any(text, g) for g in groups)
+
+def search_entries(entries, q):
+    words = run_phi4(q.strip())
+    if not words:
+        return []
+    groups = expand_groups(words)
+    return [e for e in entries if entry_matches(e, groups)]
+
+def fetch_article(entry):
+    path = os.path.join(BASE_DIR, entry['source'])
+    df = pd.read_csv(path)
+    row = df.iloc[entry['row'] - 1]
+    return row.get('記事本文', '')
+
+def create_markdown(entry, article):
+    return f"# {entry['article_title']}\n\n- 自治体: {entry['municipality']}\n- 日付: {entry['date']}\n- 号: {entry['issue_title']}\n- カテゴリ: {entry['category']}\n\n{article}"
+
+def build_markdown(results):
+    out = ''
+    for e in results:
+        article = fetch_article(e)
+        out += create_markdown(e, article) + '\n\n'
+    return out.strip()
+
+def append_log(user: str, query: str):
+    gist = os.getenv('LOG_GIST_ID')
+    token = os.getenv('GH_TOKEN')
+    if not gist or not token:
+        return
+    headers = {'Authorization': f'token {token}', 'Accept': 'application/vnd.github+json'}
+    url = f'https://api.github.com/gists/{gist}'
+    try:
+        resp = requests.get(url, headers=headers)
+        if resp.status_code != 200:
+            return
+        data = resp.json()
+        content = data['files'].get('access.log', {}).get('content', '')
+        content += json.dumps({'time': datetime.datetime.utcnow().isoformat(), 'user': user, 'query': query}, ensure_ascii=False) + '\n'
+        patch = {'files': {'access.log': {'content': content}}}
+        requests.patch(url, headers=headers, json=patch)
+    except Exception as e:
+        print('log error', e)
+
+def is_collaborator(username: str) -> bool:
+    token = os.getenv('GH_TOKEN')
+    if not token:
+        return False
+    headers = {'Authorization': f'token {token}', 'Accept': 'application/vnd.github+json'}
+    url = f'https://api.github.com/repos/{REPO}/collaborators/{username}'
+    r = requests.get(url, headers=headers)
+    return r.status_code == 204
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    auth = req.headers.get('Authorization')
+    if not auth or not auth.startswith('Bearer '):
+        return func.HttpResponse('unauthorized', status_code=401)
+    token = auth.split(' ', 1)[1]
+    user = github_user(token)
+    if not user:
+        return func.HttpResponse('unauthorized', status_code=401)
+    if not is_collaborator(user.get('login')):
+        return func.HttpResponse('forbidden', status_code=403)
+
+    if req.params.get('check'):
+        return func.HttpResponse(status_code=204)
+
+    q = req.params.get('q') or req.get_json().get('q') if req.get_body() else None
+    if not q:
+        return func.HttpResponse('missing query', status_code=400)
+
+    results = search_entries(INDEX, q)
+    limited = results[:20]
+    format_md = req.params.get('format') == 'markdown'
+    append_log(user.get('login'), q)
+
+    if format_md:
+        md = build_markdown(limited)
+        return func.HttpResponse(md, mimetype='text/markdown')
+    else:
+        body = json.dumps(limited, ensure_ascii=False)
+        return func.HttpResponse(body, mimetype='application/json')

--- a/mcp_server/advsearch/function.json
+++ b/mcp_server/advsearch/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get", "post"]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/mcp_server/exchange_token/__init__.py
+++ b/mcp_server/exchange_token/__init__.py
@@ -1,0 +1,25 @@
+import os
+import json
+import requests
+import azure.functions as func
+
+CLIENT_ID = os.getenv('GITHUB_CLIENT_ID')
+CLIENT_SECRET = os.getenv('GITHUB_CLIENT_SECRET')
+
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    code = req.params.get('code') or (req.get_json().get('code') if req.get_body() else None)
+    if not code:
+        return func.HttpResponse('missing code', status_code=400)
+    data = {
+        'client_id': CLIENT_ID,
+        'client_secret': CLIENT_SECRET,
+        'code': code
+    }
+    headers = {'Accept': 'application/json'}
+    r = requests.post('https://github.com/login/oauth/access_token', data=data, headers=headers)
+    if r.status_code != 200:
+        return func.HttpResponse('oauth error', status_code=500)
+    token = r.json().get('access_token')
+    body = json.dumps({'token': token})
+    return func.HttpResponse(body, mimetype='application/json')

--- a/mcp_server/exchange_token/function.json
+++ b/mcp_server/exchange_token/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get", "post"]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/mcp_server/requirements.txt
+++ b/mcp_server/requirements.txt
@@ -1,2 +1,3 @@
 azure-functions
 pandas
+requests


### PR DESCRIPTION
## Summary
- add link to the advanced search page from the main page with note on GitHub login
- document that index updates are now manual to reduce Phi4 token usage
- restrict the advanced search page to repository collaborators only

## Testing
- `python -m py_compile mcp_server/advsearch/__init__.py mcp_server/exchange_token/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_684fa39bc09483209852bb4cf4b38413