### PR TITLE
Add English documentation and pages

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -1,0 +1,46 @@
+# Municipal-Bulletin
+
+This repository provides a database of municipal bulletins. Article data is stored in CSV format under the `csv/` folder.
+
+## Search Page
+
+The contents of the `docs/` folder are published via GitHub Pages. You can access the search page at `docs/index.html`. It loads an index (`docs/index.json`) and performs keyword searches. Article bodies are fetched from the CSV files on demand and displayed or downloaded in Markdown format.
+
+[Bulletin Search Page](https://mitsuo-koikawa.github.io/Municipal-Bulletin)
+
+An [advanced search page](https://mitsuo-koikawa.github.io/Municipal-Bulletin/advanced.html) is also available. It requires GitHub authentication and is limited to repository collaborators. Text you provide is analyzed with GitHub Models **Phi4** to find related articles. Access logs are kept on GitHub storage for 30 days.
+
+## Updating the Index
+
+CSV files are not automatically indexed. Previously, `.github/workflows/update-index.yml` ran automatically, but to reduce token usage for GitHub Models **Phi4**, indexing is now performed manually. Use `scripts/update_index.py` to generate the index; if it fails, a simplified fallback will be used.
+
+### Manual Execution
+
+```bash
+pip install -r requirements.txt
+python scripts/update_index.py
+```
+
+Commit the generated `docs/index.json` file.
+
+## CSV Encoding Check
+
+CSV file encoding is always validated by GitHub Actions (`.github/workflows/ensure-utf8.yml`). Files saved in encodings other than UTF-8 will be automatically converted to UTF-8 and committed to the repository.
+
+## MCP Server
+
+The `mcp_server/` directory contains an Azure Functions app that searches the CSV using the `docs/index.json` index. Send a query parameter `q` to the `/api/search` HTTP endpoint to get results in JSON. Specify `format=markdown` to include the article text as Markdown.
+
+Deployment is performed by manually running `.github/workflows/deploy-mcp.yml`. Set the following secrets:
+
+- `AZURE_CREDENTIALS` – service principal credentials
+- `REGISTRY_LOGIN_SERVER` – container registry login server
+- `REGISTRY_USERNAME` – registry username
+- `REGISTRY_PASSWORD` – registry password
+- `IMAGE_NAME` – image name (e.g., contoso.azurecr.io/mcp-server)
+- `FUNCTION_APP_NAME` – name of the target Function App
+
+## License
+
+Source code in this repository is released under the [Apache License 2.0](./LICENSE).
+Data in the `csv/` folder and elsewhere is provided under the [Creative Commons Attribution 4.0 International](./LICENSE-CC-BY-4.0.txt) license.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Municipal-Bulletin
 
+English version available: [README-en.md](README-en.md)
+
 地方自治体の広報誌データベースです。`csv/` フォルダに CSV 形式で記事データを保管しています。
 
 ## 検索ページ

--- a/docs/advanced.html
+++ b/docs/advanced.html
@@ -6,6 +6,9 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
+<div id="license" style="text-align: right; position: absolute; right: 0; top: 0;">
+  <a href="advanced_en.html" style="margin-right: 10px;">English</a>
+</div>
 <h1>高度な検索</h1>
 <p>このページは本リポジトリの Collaborator のみ利用できます。</p>
 <div id="login">

--- a/docs/advanced_en.html
+++ b/docs/advanced_en.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Advanced Search</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div id="license" style="text-align: right; position: absolute; right: 0; top: 0;">
+  <a href="advanced.html" style="margin-right: 10px;">日本語</a>
+</div>
+<h1>Advanced Search</h1>
+<p>This page is available only to collaborators of this repository.</p>
+<div id="login">
+  <button id="loginBtn">Login with GitHub</button>
+</div>
+<div id="searchSection" style="display:none">
+  <textarea id="query" placeholder="Enter text" style="width:80%;height:4em;"></textarea>
+  <button id="searchBtn">Search</button>
+  <button id="downloadBtn" style="display:none">Download</button>
+  <div id="spinner" class="spinner" style="display:none"></div>
+  <div id="results"></div>
+</div>
+<script src="advanced.js"></script>
+</body>
+</html>

--- a/docs/index_en.html
+++ b/docs/index_en.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>広報誌検索</title>
+<title>Bulletin Search</title>
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <div id="license" style="text-align: right; position: absolute; right: 0; top: 0;">
-  <a href="index_en.html" style="margin-right: 10px;">English</a>
+  <a href="index.html" style="margin-right: 10px;">日本語</a>
   <a href="https://github.com/Mitsuo-Koikawa/Municipal-Bulletin" style="margin-right: 10px;">
     <img alt="GitHub" src="https://github.com/fluidicon.png" style="border-width:0; vertical-align: middle; width: 32px; height: 32px;">
   </a>
@@ -15,11 +15,11 @@
     <img alt="CC BY 4.0" src="https://licensebuttons.net/l/by/4.0/88x31.png" style="border-width:0; vertical-align: middle;">
   </a>
 </div>
-<p><a href="advanced.html">高度な検索(要 GitHub 認証・Collaborator 限定)</a></p>
-<h1>広報誌検索</h1>
-<input type="text" id="query" placeholder="検索ワードを入力" style="width:80%;">
-<button id="searchBtn">検索</button>
-<button id="downloadBtn" style="display:none">ダウンロード</button>
+<p><a href="advanced_en.html">Advanced Search (GitHub sign-in required, Collaborators only)</a></p>
+<h1>Bulletin Search</h1>
+<input type="text" id="query" placeholder="Enter keywords" style="width:80%;">
+<button id="searchBtn">Search</button>
+<button id="downloadBtn" style="display:none">Download</button>
 <div id="spinner" class="spinner" style="display:none"></div>
 <div id="results"></div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.3.2/papaparse.min.js"></script>


### PR DESCRIPTION
## Summary
- add English README
- link to English README in the Japanese version
- add English pages for GitHub Pages
- add language switch links between JP and EN pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685174179d0c8320beb43a104564b94f